### PR TITLE
Update datadog_agent_version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ datadog_user: dd-agent
 datadog_group: dd-agent
 
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
-datadog_agent_version: "1:5.17.1-1"
+datadog_agent_version: "1:5.21.1-1"
 datadog_agent_allow_downgrade: no
 
 datadog_log_retention: 1


### PR DESCRIPTION
Update datadog agent version from "1:5.17.1-1" to "1:5.21.1-1", see TOSD-3143.