### PR TITLE
Fix grep command when checking version

### DIFF
--- a/tasks/configured.yml
+++ b/tasks/configured.yml
@@ -2,7 +2,7 @@
 - block:
     - block:
         - name: check current running datadog-agent version
-          shell: "dpkg -s datadog-agent | grep Version | awk '{print $2}'"
+          shell: "dpkg -s datadog-agent | grep Version -m 1 | awk '{print $2}'"
           register: installed_dd_agent_version
 
         - assert:

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -14,7 +14,7 @@
 
     - block:
         - name: check current running datadog-agent version
-          shell: "dpkg -s datadog-agent | grep Version | awk '{print $2}'"
+          shell: "dpkg -s datadog-agent | grep Version -m 1 | awk '{print $2}'"
           register: installed_dd_agent_version
 
         - assert:


### PR DESCRIPTION
There is a problem when running this playbook with Datadog version `1:5.32.7-1`. The command `dpkg -s datadog-agent | grep Version` outputs:

```
Version: 1:5.32.7-1
Config-Version: 1:5.21.1-1
```

and this causes parsing error down the line.

This PR modifies the grep using the `-m` flag to just output the first line, since that's what we're looking for anyway. Another alternative would be to use `grep "^Version"` instead to ensure that the Version is at the start of the line.

Please let me know which fix you would prefer.