### PR TITLE
Override expvar_port and cmd_port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,10 +6,12 @@ datadog_user: dd-agent
 datadog_group: dd-agent
 
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
-datadog_agent_version: "1:5.32.7-1"
+datadog_agent_version: "1:7.32.4-1"
 datadog_agent_allow_downgrade: no
 
 datadog_log_retention: 1
 datadog_log_size: "10MB"
 
+datadog_expvar_port: "18123"
+datadog_cmd_port: "18124"
 datadog_dogstatsd_port: "18125"

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -23,6 +23,7 @@
         path: "{{ item }}"
         state: absent
       with_items:
-        - "/etc/dd-agent"
+        - "{{ datadog_legacy_config_path }}"
+        - "{{ datadog_config_path }}"
         - "/var/log/datadog"
   become: true

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -3,9 +3,9 @@ site: datadoghq.com
 {% if datadog_dogstatsd_port is defined  %}
 dogstatsd_port: {{ datadog_dogstatsd_port }}
 {% endif %}
-{% if datadog_dogstatsd_port is defined  %}
-dogstatsd_port: {{ datadog_dogstatsd_port }}
+{% if datadog_expvar_port is defined  %}
+expvar_port: {{ datadog_expvar_port }}
 {% endif %}
-{% if datadog_dogstatsd_port is defined  %}
-dogstatsd_port: {{ datadog_dogstatsd_port }}
+{% if datadog_cmd_port is defined  %}
+cmd_port: {{ datadog_cmd_port }}
 {% endif %}

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -3,3 +3,9 @@ site: datadoghq.com
 {% if datadog_dogstatsd_port is defined  %}
 dogstatsd_port: {{ datadog_dogstatsd_port }}
 {% endif %}
+{% if datadog_dogstatsd_port is defined  %}
+dogstatsd_port: {{ datadog_dogstatsd_port }}
+{% endif %}
+{% if datadog_dogstatsd_port is defined  %}
+dogstatsd_port: {{ datadog_dogstatsd_port }}
+{% endif %}


### PR DESCRIPTION
# Summary
- Modify expvar_port from port 5000 to 18123
- Modify cmd_port from port 5001 to 18124
- Modify default version installed from v5 to v7
- Update absent.yml to reflect new configuration files.